### PR TITLE
Add arm and arm64 builds to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ project_name: vault-unseal
 builds:
   - binary: vault-unseal
     goos: [linux]
-    goarch: [amd64]
+    goarch: [amd64, arm, arm64]
     ldflags: -s -w -X main.version=v{{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 nfpms:
   - homepage: https://github.com/lrstanley/vault-unseal


### PR DESCRIPTION
This PR adds the `arm` and `arm64` architectures to `.goreleaser.yml`.