### PR TITLE
Add additional SMTP TLS options

### DIFF
--- a/example.vault-unseal.yaml
+++ b/example.vault-unseal.yaml
@@ -54,6 +54,11 @@ email:
   send_addrs:
     - your-alert-group@hostname.com
     - example-user@hostname.com
+  # Skip TLS certificate validation.
+  tls_skip_verify: false
+  # Require TLS for SMTP connections.
+  # The default is opportunistic.
+  mandatory_tls: false
 
 # notifications in vault-unseal queue up to prevent email spam (e.g. 20 alerts
 # in one email). this is the max allotted time an event can be queued before

--- a/main.go
+++ b/main.go
@@ -60,13 +60,15 @@ type Config struct {
 	NotifyQueueDelay time.Duration `env:"NOTIFY_QUEUE_DELAY" long:"notify-queue-delay" description:"time we queue the notification to allow as many notifications to be sent in one go (e.g. if no notification within X time, send all notifications)" yaml:"notify_queue_delay"`
 
 	Email struct {
-		Enabled   bool     `env:"EMAIL_ENABLED" long:"enabled" description:"enables email support" yaml:"enabled"`
-		Hostname  string   `env:"EMAIL_HOSTNAME" long:"hostname" description:"hostname of mail server" yaml:"hostname"`
-		Port      int      `env:"EMAIL_PORT" long:"port" description:"port of mail server" yaml:"port"`
-		Username  string   `env:"EMAIL_USERNAME" long:"username" description:"username to authenticate to mail server" yaml:"username"`
-		Password  string   `env:"EMAIL_PASSWORD" long:"password" description:"password to authenticate to mail server" yaml:"password"`
-		FromAddr  string   `env:"EMAIL_FROM_ADDR" long:"from-addr" description:"address to use as 'From'" yaml:"from_addr"`
-		SendAddrs []string `env:"EMAIL_SEND_ADDRS" long:"send-addrs" description:"addresses to send notifications to" yaml:"send_addrs"`
+		Enabled       bool     `env:"EMAIL_ENABLED" long:"enabled" description:"enables email support" yaml:"enabled"`
+		Hostname      string   `env:"EMAIL_HOSTNAME" long:"hostname" description:"hostname of mail server" yaml:"hostname"`
+		Port          int      `env:"EMAIL_PORT" long:"port" description:"port of mail server" yaml:"port"`
+		Username      string   `env:"EMAIL_USERNAME" long:"username" description:"username to authenticate to mail server" yaml:"username"`
+		Password      string   `env:"EMAIL_PASSWORD" long:"password" description:"password to authenticate to mail server" yaml:"password"`
+		FromAddr      string   `env:"EMAIL_FROM_ADDR" long:"from-addr" description:"address to use as 'From'" yaml:"from_addr"`
+		SendAddrs     []string `env:"EMAIL_SEND_ADDRS" long:"send-addrs" description:"addresses to send notifications to" yaml:"send_addrs"`
+		TLSSkipVerify bool     `env:"EMAIL_TLS_SKIP_VERIFY" long:"tls-skip-verify" description:"skip SMTP TLS certificate validation" yaml:"tls_skip_verify"`
+		MandatoryTLS  bool     `env:"EMAIL_MANDATORY_TLS" long:"mandatory-tls" description:"require TLS for SMTP connections. Defaults to opportunistic." yaml:"mandatory_tls"`
 	} `group:"Email Options" namespace:"email" yaml:"email"`
 
 	lastModifiedCheck time.Time

--- a/notifier.go
+++ b/notifier.go
@@ -85,7 +85,10 @@ func sendQueue() {
 	var err error
 
 	smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
-	smtp.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	smtp.TLSConfig = &tls.Config{InsecureSkipVerify: conf.Email.TLSSkipVerify}
+	if conf.Email.MandatoryTLS {
+		smtp.StartTLSPolicy = mail.MandatoryStartTLS
+	}
 	smtp.LocalName, err = os.Hostname()
 	if err != nil {
 		smtp.LocalName = "localhost"


### PR DESCRIPTION
This PR adds 2 SMTP TLS options:

- mandatory_tls: require TLS for SMTP connections. Defaults to opportunistic.
- tls_skip_verify: (potentially breaking) Makes `InsecureSkipVerify` configurable, defaults to `false`.