### PR TITLE
Add ServerName to TLSConfig

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -85,7 +85,7 @@ func sendQueue() {
 	var err error
 
 	smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
-	smtp.TLSConfig = &tls.Config{InsecureSkipVerify: conf.Email.TLSSkipVerify}
+	smtp.TLSConfig = &tls.Config{InsecureSkipVerify: conf.Email.TLSSkipVerify, ServerName: conf.Email.Hostname}
 	if conf.Email.MandatoryTLS {
 		smtp.StartTLSPolicy = mail.MandatoryStartTLS
 	}


### PR DESCRIPTION
In #6 I forgot to include `ServerName` in the smtp `TLSConfig`:

```
level=error message="unable to make smtp connection" environment= error="tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config"
```