### PR TITLE
Support secret files permission 440 for OKD Openshift

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func readConfig(path string) error {
 			return err
 		}
 
-		if perms := permbits.FileMode(fi.Mode()); perms != 0o600 && perms != 0o400 {
+		if perms := permbits.FileMode(fi.Mode()); perms != 0o600 && perms != 0o400 && perms != 0o440 {
 			return fmt.Errorf("permissions of %q are insecure: %s, please use 0600 or 0400", path, perms)
 		}
 

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func readConfig(path string) error {
 		}
 
 		if perms := permbits.FileMode(fi.Mode()); perms != 0o600 && perms != 0o400 && perms != 0o440 {
-			return fmt.Errorf("permissions of %q are insecure: %s, please use 0600 or 0400", path, perms)
+			return fmt.Errorf("permissions of %q are insecure: %s, please use 0600, 0440, or 0400", path, perms)
 		}
 
 		// Check to see if it's updated.


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to vault-unseal! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

Add new permission on secret file to 440 according to OKD Openshift policy. 

### 🧰 Type of change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.


