### PR TITLE
Add TLS configuration

### DIFF
--- a/devenv/vault-unseal.yaml
+++ b/devenv/vault-unseal.yaml
@@ -1,6 +1,7 @@
 email:
   enabled: false
-tls_skip_verify: true
+tls:
+  insecure: true
 unseal_tokens:
   - YOUR_TOKEN_HERE
 vault_nodes:

--- a/example.vault-unseal.yaml
+++ b/example.vault-unseal.yaml
@@ -38,7 +38,8 @@ unseal_tokens:
 
 # skip tls checks for the given vault instance. useful if your instance doesn't
 # have a certificate which has all of the server hostnames on it.
-tls_skip_verify: false
+tls:
+  insecure: false
 
 # email notifications. setting this to false will disable all notifications.
 email:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/joho/godotenv v1.5.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -33,7 +34,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to vault-unseal! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

I propose to add full TLS configuration for vault client.

```go
TLS struct {
	CACert        string `env:"TLS_CA_CERT" long:"ca-cert" description:"the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate. It takes precedence over CACertBytes and CAPath" yaml:"ca_cert"`
	CACertBytes   []byte `env:"TLS_CA_CERT_BYTES" long:"ca-cert-bytes" description:"PEM-encoded certificate or bundle. It takes precedence over CAPath" yaml:"ca_cert_bytes"`
	CAPath        string `env:"TLS_CA_PATH" long:"ca-path" description:"path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate" yaml:"ca_path"`
	ClientCert    string `env:"TLS_CLIENT_CERT" long:"client-cert" description:"path to the certificate for Vault communication" yaml:"client_path"`
	ClientKey     string `env:"TLS_CLIENT_KEY" long:"client-key" description:"path to the private key for Vault communication" yaml:"client_key"`
	TLSServerName string `env:"TLS_SERVER_NAME" long:"server-name" description:"if set, is used to set the SNI host when connecting via TLS" yaml:"server_name"`
	Insecure      bool   `env:"TLS_INSECURE" long:"insecure" description:"enables or disables SSL verification: DO NOT DO THIS" yaml:"insecure"`
} `group:"TLS Options" namespace:"tls" yaml:"tls"`
```

`tls_skip_verify`is replaced by `insecure` parameter in `tls`struct.

i.e:

```go
tls:
  insecure: false
```

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.



