### PR TITLE
Adds simple mattermost notifier

### DIFF
--- a/example.vault-unseal.yaml
+++ b/example.vault-unseal.yaml
@@ -60,6 +60,11 @@ email:
   # The default is opportunistic.
   mandatory_tls: false
 
+# mattermost webhook notification
+mattermost:
+  enabled: false
+  webhook: https://your-mattermost-server.com/hooks/xxx-generatedkey-xxx
+
 # notifications in vault-unseal queue up to prevent email spam (e.g. 20 alerts
 # in one email). this is the max allotted time an event can be queued before
 # the queue is sent as a notification.

--- a/main.go
+++ b/main.go
@@ -78,6 +78,11 @@ type Config struct {
 		MandatoryTLS  bool     `env:"EMAIL_MANDATORY_TLS"   long:"mandatory-tls"   description:"require TLS for SMTP connections. Defaults to opportunistic." yaml:"mandatory_tls"`
 	} `group:"Email Options" namespace:"email" yaml:"email"`
 
+	Mattermost struct {
+		Enabled       bool     `env:"MATTERMOST_ENABLED"         long:"enabled"         description:"enables mattermost webhook support" yaml:"enabled"`
+		Webhook 	  string   `env:"MATTERMOST_WEBHOOK"        long:"webhook"        description:"webhook" yaml:"webhook"`
+	} `group:"Mattermost webhook options" namespace:"mattermost" yaml:"mattermost"`
+
 	lastModifiedCheck time.Time
 }
 

--- a/notifier.go
+++ b/notifier.go
@@ -129,11 +129,11 @@ func sendQueue() {
 
 		err = mail.Send(s, msg)
 		if err != nil {
-			logger.WithError(err).Error("unable to send notification")
+			logger.WithError(err).Error("unable to send email notification")
 			return
 		}
 
-		logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent notifications")
+		logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent email notifications")
 	}
 
 	if conf.Mattermost.Enabled {
@@ -151,7 +151,7 @@ func sendQueue() {
 
 		jsonData, err := json.Marshal(data)
 		if err != nil {
-			fmt.Println("Error encoding JSON:", err)
+			logger.Errorf("error encoding mattermost webhook payload json:", err)
 			return
 		}
 
@@ -161,7 +161,7 @@ func sendQueue() {
 
 		req, err := http.NewRequest("POST", conf.Mattermost.Webhook, bytes.NewBuffer(jsonData))
 		if err != nil {
-			logger.Infof("Error creating request:", err)
+			logger.Errorf("error creating mattermost webhook post request:", err)
 			return
 		}
 
@@ -169,10 +169,15 @@ func sendQueue() {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			logger.Infof("Error sending request:", err)
+			logger.Errorf("error sending mattermost webhook post request:", err)
 			return
 		}
 		defer resp.Body.Close()
+
+		if resp.StatusCode == 200 {
+			logger.Info("successfully sent mattermost notifications")
+		}
+
 	}
 
 	notifyQueue = nil

--- a/notifier.go
+++ b/notifier.go
@@ -5,9 +5,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -27,15 +30,17 @@ type notifyError struct {
 	err       error
 }
 
+type MattermostPayload struct {
+	Text string `json:"text"`
+}
+
 func notify(err error) {
 	err = fmt.Errorf("error: %w", err)
 	logger.WithError(err).Error("notify-error")
 
-	if !conf.Email.Enabled {
-		return
+	if conf.Email.Enabled || conf.Mattermost.Enabled {
+		notifyCh <- err
 	}
-
-	notifyCh <- err
 }
 
 func notifier(ctx context.Context, wg *sync.WaitGroup) {
@@ -82,50 +87,93 @@ func sendQueue() {
 		text += fmt.Sprintf("\n%s :: %v", notifyQueue[i].timestamp.Format(time.RFC822), notifyQueue[i].err)
 	}
 
-	var err error
+	if conf.Email.Enabled {
 
-	smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
-	smtp.TLSConfig = &tls.Config{
-		InsecureSkipVerify: conf.Email.TLSSkipVerify, //nolint:gosec
-		ServerName:         conf.Email.Hostname,
+		var err error
+
+		smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
+		smtp.TLSConfig = &tls.Config{
+			InsecureSkipVerify: conf.Email.TLSSkipVerify, //nolint:gosec
+			ServerName:         conf.Email.Hostname,
+		}
+
+		if conf.Email.MandatoryTLS {
+			smtp.StartTLSPolicy = mail.MandatoryStartTLS
+		}
+
+		smtp.LocalName, err = os.Hostname()
+		if err != nil {
+			smtp.LocalName = "localhost"
+		}
+
+		s, err := smtp.Dial()
+		if err != nil {
+			logger.WithError(err).WithFields(log.Fields{
+				"hostname": conf.Email.Hostname,
+				"port":     conf.Email.Port,
+			}).Error("unable to make smtp connection")
+			return
+		}
+
+		text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, smtp.LocalName)
+
+		msg := mail.NewMessage()
+		msg.SetHeader("From", conf.Email.FromAddr)
+		msg.SetHeader("Subject", fmt.Sprintf("vault-unseal: %s: %d errors occurred", conf.Environment, len(notifyQueue)))
+		msg.SetBody("text/plain", text)
+
+		msg.SetHeader("To", conf.Email.SendAddrs[0])
+		if len(conf.Email.SendAddrs) > 1 {
+			msg.SetHeader("CC", conf.Email.SendAddrs[1:]...)
+		}
+
+		err = mail.Send(s, msg)
+		if err != nil {
+			logger.WithError(err).Error("unable to send notification")
+			return
+		}
+
+		logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent notifications")
 	}
 
-	if conf.Email.MandatoryTLS {
-		smtp.StartTLSPolicy = mail.MandatoryStartTLS
+	if conf.Mattermost.Enabled {
+
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = "localhost"
+		}
+
+		text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, hostname)
+
+		data := MattermostPayload{
+			Text: text,
+		}
+
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			fmt.Println("Error encoding JSON:", err)
+			return
+		}
+
+		client := &http.Client{
+			Timeout: 10 * time.Second,
+		}
+
+		req, err := http.NewRequest("POST", conf.Mattermost.Webhook, bytes.NewBuffer(jsonData))
+		if err != nil {
+			logger.Infof("Error creating request:", err)
+			return
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			logger.Infof("Error sending request:", err)
+			return
+		}
+		defer resp.Body.Close()
 	}
 
-	smtp.LocalName, err = os.Hostname()
-	if err != nil {
-		smtp.LocalName = "localhost"
-	}
-
-	s, err := smtp.Dial()
-	if err != nil {
-		logger.WithError(err).WithFields(log.Fields{
-			"hostname": conf.Email.Hostname,
-			"port":     conf.Email.Port,
-		}).Error("unable to make smtp connection")
-		return
-	}
-
-	text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, smtp.LocalName)
-
-	msg := mail.NewMessage()
-	msg.SetHeader("From", conf.Email.FromAddr)
-	msg.SetHeader("Subject", fmt.Sprintf("vault-unseal: %s: %d errors occurred", conf.Environment, len(notifyQueue)))
-	msg.SetBody("text/plain", text)
-
-	msg.SetHeader("To", conf.Email.SendAddrs[0])
-	if len(conf.Email.SendAddrs) > 1 {
-		msg.SetHeader("CC", conf.Email.SendAddrs[1:]...)
-	}
-
-	err = mail.Send(s, msg)
-	if err != nil {
-		logger.WithError(err).Error("unable to send notification")
-		return
-	}
-
-	logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent notifications")
 	notifyQueue = nil
 }

--- a/notifier.go
+++ b/notifier.go
@@ -88,97 +88,103 @@ func sendQueue() {
 	}
 
 	if conf.Email.Enabled {
-
-		var err error
-
-		smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
-		smtp.TLSConfig = &tls.Config{
-			InsecureSkipVerify: conf.Email.TLSSkipVerify, //nolint:gosec
-			ServerName:         conf.Email.Hostname,
-		}
-
-		if conf.Email.MandatoryTLS {
-			smtp.StartTLSPolicy = mail.MandatoryStartTLS
-		}
-
-		smtp.LocalName, err = os.Hostname()
-		if err != nil {
-			smtp.LocalName = "localhost"
-		}
-
-		s, err := smtp.Dial()
-		if err != nil {
-			logger.WithError(err).WithFields(log.Fields{
-				"hostname": conf.Email.Hostname,
-				"port":     conf.Email.Port,
-			}).Error("unable to make smtp connection")
-			return
-		}
-
-		text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, smtp.LocalName)
-
-		msg := mail.NewMessage()
-		msg.SetHeader("From", conf.Email.FromAddr)
-		msg.SetHeader("Subject", fmt.Sprintf("vault-unseal: %s: %d errors occurred", conf.Environment, len(notifyQueue)))
-		msg.SetBody("text/plain", text)
-
-		msg.SetHeader("To", conf.Email.SendAddrs[0])
-		if len(conf.Email.SendAddrs) > 1 {
-			msg.SetHeader("CC", conf.Email.SendAddrs[1:]...)
-		}
-
-		err = mail.Send(s, msg)
-		if err != nil {
-			logger.WithError(err).Error("unable to send email notification")
-			return
-		}
-
-		logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent email notifications")
+		emailNotifier(text)
 	}
 
 	if conf.Mattermost.Enabled {
-
-		hostname, err := os.Hostname()
-		if err != nil {
-			hostname = "localhost"
-		}
-
-		text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, hostname)
-
-		data := MattermostPayload{
-			Text: text,
-		}
-
-		jsonData, err := json.Marshal(data)
-		if err != nil {
-			logger.Errorf("error encoding mattermost webhook payload json:", err)
-			return
-		}
-
-		client := &http.Client{
-			Timeout: 10 * time.Second,
-		}
-
-		req, err := http.NewRequest("POST", conf.Mattermost.Webhook, bytes.NewBuffer(jsonData))
-		if err != nil {
-			logger.Errorf("error creating mattermost webhook post request:", err)
-			return
-		}
-
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			logger.Errorf("error sending mattermost webhook post request:", err)
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode == 200 {
-			logger.Info("successfully sent mattermost notifications")
-		}
-
+		mattermostNotifier(text)
 	}
 
 	notifyQueue = nil
+}
+
+func emailNotifier(text string) {
+	var err error
+
+	smtp := mail.NewDialer(conf.Email.Hostname, conf.Email.Port, conf.Email.Username, conf.Email.Password)
+	smtp.TLSConfig = &tls.Config{
+		InsecureSkipVerify: conf.Email.TLSSkipVerify, //nolint:gosec
+		ServerName:         conf.Email.Hostname,
+	}
+
+	if conf.Email.MandatoryTLS {
+		smtp.StartTLSPolicy = mail.MandatoryStartTLS
+	}
+
+	smtp.LocalName, err = os.Hostname()
+	if err != nil {
+		smtp.LocalName = "localhost"
+	}
+
+	s, err := smtp.Dial()
+	if err != nil {
+		logger.WithError(err).WithFields(log.Fields{
+			"hostname": conf.Email.Hostname,
+			"port":     conf.Email.Port,
+		}).Error("unable to make smtp connection")
+		return
+	}
+
+	text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, smtp.LocalName)
+
+	msg := mail.NewMessage()
+	msg.SetHeader("From", conf.Email.FromAddr)
+	msg.SetHeader("Subject", fmt.Sprintf("vault-unseal: %s: %d errors occurred", conf.Environment, len(notifyQueue)))
+	msg.SetBody("text/plain", text)
+
+	msg.SetHeader("To", conf.Email.SendAddrs[0])
+	if len(conf.Email.SendAddrs) > 1 {
+		msg.SetHeader("CC", conf.Email.SendAddrs[1:]...)
+	}
+
+	err = mail.Send(s, msg)
+	if err != nil {
+		logger.WithError(err).Error("unable to send email notification")
+		return
+	}
+
+	logger.WithField("to", strings.Join(conf.Email.SendAddrs, ",")).Info("successfully sent email notifications")
+}
+
+func mattermostNotifier(text string) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+
+	text += fmt.Sprintf("\n\nsent from vault-unseal. version: %s, compile date: %s, hostname: %s", version, date, hostname)
+
+	data := MattermostPayload{
+		Text: text,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		logger.Errorf("error encoding mattermost webhook payload json:", err)
+		return
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequest("POST", conf.Mattermost.Webhook, bytes.NewBuffer(jsonData))
+	if err != nil {
+		logger.Errorf("error creating mattermost webhook post request:", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Errorf("error sending mattermost webhook post request:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		logger.Info("successfully sent mattermost notifications")
+	}
+
 }


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

Adds a simple Mattermost webhook notifier. Changes:

 - Plugs into sendQueue() keeping email notifications first to be processed. 
 - Configuration follows the same pattern as for Config.Email with Config.Mattermost. 
 - Does not introduce any new external mod dependencies

### 🔗 Related bug reports/feature requests

- relates to #3

### 🧰 Type of change

- [x] New feature (non-breaking change which adds functionality).

### 📝 Notes to reviewer

Not asking to merge this but rather just a review in case you have any concerns or issue with the way this change fits in.

Might have to move email and mattermost handling into own functions and in sendQueue() have it like:

    var err = error
	if conf.Email.Enabled {
	    err = errsendEmailNotification(text)
	    // if err, log it
	}
	if conf.Mattermost.Enabled {
	    err = sendMattermostNotification(text)
	    // if err, log it
	}
	
so that each can return on errs

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
