### PR TITLE
Fix passing `CACert` and `CACertPath` to Vault API

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,8 @@ func newVault(logger *slog.Logger, addr string) (*vapi.Client, error) {
 	err = vconfig.ConfigureTLS(&vapi.TLSConfig{
 		Insecure:      c.TLS.SkipVerify || c.TLSSkipVerifyLegacy,
 		TLSServerName: c.TLS.ServerName,
-		CACert:        c.TLS.CACert,
+		CACert:        c.TLS.CACertPath,
+		CACertBytes:   []byte(c.TLS.CACert),
 		CAPath:        c.TLS.CAPath,
 		ClientCert:    c.TLS.ClientCert,
 		ClientKey:     c.TLS.ClientKey,


### PR DESCRIPTION
This fixes the bug of both `tls.ca-cert` and `tls.ca-cert-path` not taking effect.

<!--
  🙏 Thanks for submitting a pull request to vault-unseal! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

<!-- REQUIRED:
  Please include a summary of the change and which issue is fixed, or what feature is
  implemented. Include relevant motivation and context.
-->
Pass `CACert` as `CACertBytes` and `CACertPath` as `CACert` to Vault API. Currently
we're passing `CACert` in the wrong way while completely ignoring `CACertPath`.


### 🔗 Related bug reports/feature requests

<!--
  Does this PR relate to any bug reports and/or feature requests? Some examples:
  ❌ Remove section if there are no existing requests and/or issues.
-->
- fixes #(issue)
- closes #(issue)
- relates to #(issue)
- implements #(feature)

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 📝 Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR. If necessary,
  include things like screenshots (where beneficial), to help demonstrate the changes.
-->

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [ ] 📝 I have made corresponding changes to the documentation.
- [ ] 🧪 I have included tests (if necessary) for this change.
